### PR TITLE
There's no need to call init_meta - just pass the metaroles to Moose::Ex...

### DIFF
--- a/lib/MooseX/Role/WithOverloading.pm
+++ b/lib/MooseX/Role/WithOverloading.pm
@@ -19,22 +19,15 @@ XSLoader::load(
     : ()
 );
 
-Moose::Exporter->setup_import_methods(also => 'Moose::Role');
-
-sub init_meta {
-    my ($class, %opts) = @_;
-    my $meta = Moose::Role->init_meta(%opts);
-
-    return Moose::Util::MetaRole::apply_metaroles(
-        for            => $meta,
-        role_metaroles => {
-            role                    => [MetaRole],
-            application_to_class    => [ToClass],
-            application_to_role     => [ToRole],
-            application_to_instance => [ToInstance],
-        },
-    );
-}
+Moose::Exporter->setup_import_methods(
+    also           => 'Moose::Role',
+    role_metaroles => {
+        role                    => [MetaRole],
+        application_to_class    => [ToClass],
+        application_to_role     => [ToRole],
+        application_to_instance => [ToInstance],
+    },
+);
 
 1;
 


### PR DESCRIPTION
...porter
