### PR TITLE
Fix this module with 5.18+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /Makefile
 /MooseX-Role-WithOverloading-*.tar.gz
 /MooseX-Role-WithOverloading-*/
+/WithOverloading.bs
 /WithOverloading.c
 /WithOverloading.o
 /blib/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+# for what versions are available, see:
+# https://github.com/travis-ci/travis-cookbooks/blob/master/ci_environment/perlbrew/attributes/multi.rb
+language: perl
+perl:
+    #- dev
+    - "blead"
+    #- stable
+    - "5.20"
+    - "5.18"
+    - "5.16"
+    - "5.14"
+    - "5.12"
+    - "5.10"
+    - "5.8"
+before_install:
+  - git clone git://github.com/haarg/perl-travis-helper
+  - source perl-travis-helper/init
+  - build-perl
+  - perl -V
+  - build-dist
+  - cd $BUILD_DIR
+install:
+  - cpan-install YAML
+  - cpan-install ExtUtils::MakeMaker~6.68 --deps
+  - cpan-install --coverage
+script:
+  - perl Makefile.PL
+  - make
+  - RELEASE_TESTING=1 prove -b -r -s -j$((SYSTEM_CORES + 1)) $(test-dirs)

--- a/Changes
+++ b/Changes
@@ -1,10 +1,10 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
-          - line numbers in shipped code are now almost the same (within 3) as
+          - Line numbers in shipped code are now almost the same (within 3) as
             the repository source, for easier debugging
-          - repository migrated to the github moose organization
-          - unneeded init_meta method removed (Dave Rolsky)
+          - Repository migrated to the github moose organization
+          - Unneeded init_meta method removed (Dave Rolsky)
 
 0.13      2013-01-08 04:59:07Z
           - Resolve failure reports in 5.17.* due to changes in SVf_AMAGIC

--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+          - Fixed a bug with Perl 5.18+ that caused this module to simply blow
+            up with an error like "Use of uninitialized value in subroutine
+            entry at .../Class/MOP/Package.pm ..." (Dave Rolsky)
           - Line numbers in shipped code are now almost the same (within 3) as
             the repository source, for easier debugging
           - Repository migrated to the github moose organization

--- a/dist.ini
+++ b/dist.ini
@@ -3,7 +3,6 @@ author  = Florian Ragwitz <rafl@debian.org>
 author  = Tomas Doran <bobtfish@bobtfish.net>
 license = Perl_5
 copyright_holder = Florian Ragwitz
-copyright_year = 2009
 
 [@Author::ETHER]
 Authority.authority = cpan:FLORA

--- a/dist.ini
+++ b/dist.ini
@@ -12,6 +12,7 @@ installer = MakeMaker
 AutoPrereqs.skip[0] = ^MyRole
 AutoPrereqs.skip[1] = ^OverloadingRole$
 Git::GatherDir.exclude_filename[] = Makefile.PL
+Test::PodSpelling.stopwords[0] = metaclass
 
 [Prereqs]
 namespace::autoclean = 0.12

--- a/dist.ini
+++ b/dist.ini
@@ -9,7 +9,7 @@ copyright_year = 2009
 Authority.authority = cpan:FLORA
 Test::ReportPrereqs.include = Dist::CheckConflicts
 installer = MakeMaker
-AutoPrereqs.skip[0] = ^MyRole$
+AutoPrereqs.skip[0] = ^MyRole
 AutoPrereqs.skip[1] = ^OverloadingRole$
 Git::GatherDir.exclude_filename[] = Makefile.PL
 

--- a/t/combine_to_class.t
+++ b/t/combine_to_class.t
@@ -1,8 +1,8 @@
 use strict;
 use warnings;
 
-use Test::More tests => 13;
-use Test::NoWarnings 1.04 ':early';
+use Test::More 0.96;
+use Test::Warnings;
 use overload ();
 
 use lib 't/lib';
@@ -26,3 +26,4 @@ is($foo->message, 'foo');
 my $str = "${foo}";
 is($str, 'foo');
 
+done_testing();

--- a/t/combine_to_instance.t
+++ b/t/combine_to_instance.t
@@ -1,8 +1,8 @@
 use strict;
 use warnings;
 
-use Test::More tests => 7;
-use Test::NoWarnings 1.04 ':early';
+use Test::More 0.96;
+use Test::Warnings;
 use overload ();
 
 use lib 't/lib';
@@ -35,3 +35,4 @@ $foo->message('foo');
 my $str = "${foo}";
 is($str, 'foo');
 
+done_testing();

--- a/t/combine_to_role.t
+++ b/t/combine_to_role.t
@@ -1,8 +1,8 @@
 use strict;
 use warnings;
 
-use Test::More tests => 16;
-use Test::NoWarnings 1.04 ':early';
+use Test::More 0.96;
+use Test::Warnings;
 use overload ();
 
 use lib 't/lib';
@@ -29,3 +29,4 @@ is($foo->message, 'foo');
 my $str = "${foo}";
 is($str, 'foo');
 
+done_testing();

--- a/t/remove_attributes_bug.t
+++ b/t/remove_attributes_bug.t
@@ -1,8 +1,8 @@
 use strict;
 use warnings;
 
-use Test::More tests => 4;
-use Test::NoWarnings 1.04 ':early';
+use Test::More 0.96;
+use Test::Warnings;
 
 {
     package OverloadingRole;
@@ -38,3 +38,4 @@ is("$i", 'moo', 'overloading works');
 can_ok($i, 'hitid' );
 is($i->hitid, 21, 'Attribute works');
 
+done_testing();

--- a/t/to_class.t
+++ b/t/to_class.t
@@ -1,8 +1,8 @@
 use strict;
 use warnings;
 
-use Test::More tests => 10;
-use Test::NoWarnings 1.04 ':early';
+use Test::More 0.96;
+use Test::Warnings;
 use overload ();
 
 use lib 't/lib';
@@ -23,3 +23,4 @@ is($foo->message, 'foo');
 my $str = "${foo}";
 is($str, 'foo');
 
+done_testing();

--- a/t/to_instance.t
+++ b/t/to_instance.t
@@ -1,8 +1,8 @@
 use strict;
 use warnings;
 
-use Test::More tests => 7;
-use Test::NoWarnings 1.04 ':early';
+use Test::More 0.96;
+use Test::Warnings;
 use overload ();
 
 use lib 't/lib';
@@ -29,3 +29,4 @@ $foo->message('foo');
 my $str = "${foo}";
 is($str, 'foo');
 
+done_testing();

--- a/t/to_role.t
+++ b/t/to_role.t
@@ -1,8 +1,8 @@
 use strict;
 use warnings;
 
-use Test::More tests => 13;
-use Test::NoWarnings 1.04 ':early';
+use Test::More 0.96;
+use Test::Warnings;
 use overload ();
 
 use lib 't/lib';
@@ -26,3 +26,4 @@ is($foo->message, 'foo');
 my $str = "${foo}";
 is($str, 'foo');
 
+done_testing();

--- a/t/to_role.t
+++ b/t/to_role.t
@@ -26,4 +26,30 @@ is($foo->message, 'foo');
 my $str = "${foo}";
 is($str, 'foo');
 
+# These tests failed on 5.18+ without some fixes to the MXRWO internals
+{
+    package Role1;
+    use MooseX::Role::WithOverloading;
+    use overload q{""} => '_stringify';
+    sub _stringify { __PACKAGE__ };
+}
+
+{
+    package Role2;
+    use Moose::Role;
+    with 'Role1';
+}
+
+{
+    package Class1;
+    use Moose;
+    with 'Role2';
+}
+
+is(
+    Class1->new . q{},
+    'Role1',
+    'stringification overloading is passed through all roles'
+);
+
 done_testing();

--- a/t/to_role.t
+++ b/t/to_role.t
@@ -28,27 +28,27 @@ is($str, 'foo');
 
 # These tests failed on 5.18+ without some fixes to the MXRWO internals
 {
-    package Role1;
+    package MyRole1;
     use MooseX::Role::WithOverloading;
     use overload q{""} => '_stringify';
     sub _stringify { __PACKAGE__ };
 }
 
 {
-    package Role2;
+    package MyRole2;
     use Moose::Role;
-    with 'Role1';
+    with 'MyRole1';
 }
 
 {
     package Class1;
     use Moose;
-    with 'Role2';
+    with 'MyRole2';
 }
 
 is(
     Class1->new . q{},
-    'Role1',
+    'MyRole1',
     'stringification overloading is passed through all roles'
 );
 


### PR DESCRIPTION
There's also some test code cleanup in here. Everything uses done_testing and Test::Warnings (instead of Test::NoWarnings).
